### PR TITLE
Threshold aperture

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tess-asteroids"
-version = "0.1.0"
+version = "0.2.0"
 description = "Create TPFs and LCs for solar system asteroids observed by NASA's TESS mission."
 license = "MIT"
 authors = ["Amy Tuson <amy.l.tuson@nasa.gov>",

--- a/src/tess_asteroids/__init__.py
+++ b/src/tess_asteroids/__init__.py
@@ -6,5 +6,5 @@ logger.addHandler(logging.StreamHandler())
 
 from .tpf import MovingTargetTPF  # noqa: E402
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 __all__ = ["MovingTargetTPF"]

--- a/src/tess_asteroids/tpf.py
+++ b/src/tess_asteroids/tpf.py
@@ -357,7 +357,39 @@ class MovingTargetTPF:
 
         return np.asarray(bg), np.asarray(bg_err)
 
-    def create_threshold_mask(
+    def create_aperture(self, method: str = "threshold", **kwargs):
+        """
+        Creates an aperture mask using a method ['threshold', 'prf', 'ellipse'].
+        It creates the `self.aperture_mask` attribute with the 3D mask.
+
+        Parameters
+        ----------
+        method : str
+            Method used for apertrue estimation. One of ['threshold', 'prf', 'ellipse'].
+        kwargs : dict
+            Keywords arguments passed to aperture mask method, e.g
+            `self._create_threshold_mask` takes `threshold` and `reference_pixel`.
+
+        Returns
+        -------
+        """
+        if not hasattr(self, "all_flux") or not hasattr(self, "flux"):
+            raise AttributeError(
+                "Must run `get_data()` and `reshape_data()` before computing aperture mask."
+            )
+
+        # Get mask via chosen method
+        if method == "threshold":
+            self.aperture_mask = self._create_threshold_mask(**kwargs)
+        # will add these methods in a future PR
+        elif method in ["prf", "ellipse"]:
+            raise NotImplementedError(f"Method '{method}' not implemented yet.")
+        else:
+            raise ValueError(
+                f"`{method}` must be one of: ['threshold', 'prf', 'ellipse']"
+            )
+
+    def _create_threshold_mask(
         self,
         threshold: float = 3.0,
         reference_pixel: Union[str, Tuple[float, float]] = "center",
@@ -371,7 +403,7 @@ class MovingTargetTPF:
             A value for the number of sigma by which a pixel needs to be
             brighter than the median flux to be included in the aperture mask.
         reference_pixel: (int, int) tuple, 'center', or None
-            (col, row) pixel coordinate closest to the desired region.
+            (row, column) pixel coordinate closest to the desired region.
             For example, use `reference_pixel=(0,0)` to select the region
             closest to the bottom left corner of the target pixel file.
             If 'center' (default) then the region closest to the center pixel
@@ -379,46 +411,61 @@ class MovingTargetTPF:
 
         Returns
         -------
+        aperture_mask : ndarray
+            Boolean numpy array containing `True` for pixels above the
+            threshold. Shape is (ntimes, nrows, ncols)
         """
-        if not hasattr(self, "flux"):
-            raise AttributeError("Must run `reshape_data()` before computing aperture.")
+        if (
+            not hasattr(self, "all_flux")
+            or not hasattr(self, "flux")
+            or not hasattr(self, "corr_flux")
+        ):
+            raise AttributeError(
+                "Must run `get_data()`, `reshape_data()` and `background_correction()` before."
+            )
 
         if reference_pixel == "center":
             reference_pixel = (self.shape[1] / 2, self.shape[0] / 2)
 
-        self.aperture_mask = np.zeros_like(self.flux).astype(bool)
-        diff = self.flux - self.bg
+        aperture_mask = np.zeros_like(self.flux).astype(bool)
+
+        # mask with value threshold
+        median = np.nanmedian(self.corr_flux)
+        mad = stats.median_abs_deviation(self.corr_flux.ravel())
 
         # iterate over frames
         for nt in range(len(self.time)):
-            # mask with value threshold
-            median = np.nanmedian(diff)
-            mad = stats.median_abs_deviation(diff.ravel())
             # Calculate the theshold value and mask
-            self.aperture_mask[nt] = diff[nt] >= (1.4826 * mad * threshold) + median
+            # std is estimated in a robust way by multiplying the MAD with 1.4826
+            aperture_mask[nt] = (
+                self.corr_flux[nt] >= (1.4826 * mad * threshold) + median
+            )
             # skip frames with zero mask
-            if self.aperture_mask[nt].sum() == 0:
+            if aperture_mask[nt].sum() == 0:
                 continue
             # keep all pixels above threhold if asked
             if reference_pixel is None:
                 continue
 
             # find mask patch closest to reference_pixel
-            labels = ndimage.label(self.aperture_mask[nt])[0]
+            # `label` assignd number labels to each contiguous `True`` values in the threshold
+            # mask, this is useful to find unique mask patches and isolate the one closer to
+            # `reference pixel`
+            labels = ndimage.label(aperture_mask[nt])[0]
             # For all pixels above threshold, compute distance to reference pixel:
             label_args = np.argwhere(labels > 0)
             distances = [
                 np.hypot(crd[0], crd[1])
                 for crd in label_args
-                - np.array([reference_pixel[1], reference_pixel[0]])
+                - np.array([reference_pixel[0], reference_pixel[1]])
             ]
             # Which label corresponds to the closest pixel
             closest_arg = label_args[np.argmin(distances)]
             closest_label = labels[closest_arg[0], closest_arg[1]]
             # update mask with closest patch
-            self.aperture_mask[nt] = labels == closest_label
+            aperture_mask[nt] = labels == closest_label
 
-        return
+        return aperture_mask
 
     def save_data(
         self,

--- a/src/tess_asteroids/tpf.py
+++ b/src/tess_asteroids/tpf.py
@@ -3,10 +3,10 @@ from typing import Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
-from scipy import stats, ndimage
 from astropy.coordinates import SkyCoord
 from astropy.io import fits
 from astropy.wcs.utils import fit_wcs_from_points
+from scipy import ndimage, stats
 from tess_ephem import ephem
 from tesscube import TESSCube
 from tesscube.fits import get_wcs_header_by_extension
@@ -360,7 +360,7 @@ class MovingTargetTPF:
     def create_threshold_mask(
         self,
         threshold: float = 3.0,
-        reference_pixel: Union[str, Tuple[int, int]] = "center",
+        reference_pixel: Union[str, Tuple[float, float]] = "center",
     ):
         """
         Get aperture for LC extraction.

--- a/tests/test_tpf.py
+++ b/tests/test_tpf.py
@@ -98,8 +98,8 @@ def test_make_tpf():
     # Delete the file
     os.remove("tests/tess-1998YT6-s0006-shape11x11-moving_tp.fits")
 
+
 def test_create_threshold_mask():
-    
     # Make TPF for asteroid 1998 YT6
     test, _ = MovingTargetTPF.from_name("1998 YT6", sector=6)
     test.get_data(shape=(11, 11))
@@ -109,5 +109,7 @@ def test_create_threshold_mask():
     test.create_threshold_mask(reference_pixel="center")
 
     assert test.aperture_mask.shape == test.flux.shape
-    assert np.median(test.aperture_mask.reshape((test.time.shape[0], -1)).sum(axis=1)) == 7.0
-
+    assert (
+        np.median(test.aperture_mask.reshape((test.time.shape[0], -1)).sum(axis=1))
+        == 7.0
+    )

--- a/tests/test_tpf.py
+++ b/tests/test_tpf.py
@@ -100,16 +100,20 @@ def test_make_tpf():
 
 
 def test_create_threshold_mask():
+    """
+    Test threshold mask method that creates an aperture mask at each frame
+    of flux pixels > threshold * STD.
+    We test that the return mask has the same shape as `self.flux` and
+    that expected median number of pixels in the mask for the test asteroid
+    is a fixed numer (7).
+    """
     # Make TPF for asteroid 1998 YT6
     test, _ = MovingTargetTPF.from_name("1998 YT6", sector=6)
     test.get_data(shape=(11, 11))
     test.reshape_data()
     test.background_correction(method="rolling")
 
-    test.create_threshold_mask(reference_pixel="center")
+    aperture_mask = test._create_threshold_mask(threshold=3.0, reference_pixel="center")
 
-    assert test.aperture_mask.shape == test.flux.shape
-    assert (
-        np.median(test.aperture_mask.reshape((test.time.shape[0], -1)).sum(axis=1))
-        == 7.0
-    )
+    assert aperture_mask.shape == test.flux.shape
+    assert np.median(aperture_mask.reshape((test.time.shape[0], -1)).sum(axis=1)) == 7.0

--- a/tests/test_tpf.py
+++ b/tests/test_tpf.py
@@ -97,3 +97,17 @@ def test_make_tpf():
 
     # Delete the file
     os.remove("tests/tess-1998YT6-s0006-shape11x11-moving_tp.fits")
+
+def test_create_threshold_mask():
+    
+    # Make TPF for asteroid 1998 YT6
+    test, _ = MovingTargetTPF.from_name("1998 YT6", sector=6)
+    test.get_data(shape=(11, 11))
+    test.reshape_data()
+    test.background_correction(method="rolling")
+
+    test.create_threshold_mask(reference_pixel="center")
+
+    assert test.aperture_mask.shape == test.flux.shape
+    assert np.median(test.aperture_mask.reshape((test.time.shape[0], -1)).sum(axis=1)) == 7.0
+


### PR DESCRIPTION
It is adding a method to compute the threshold mask for every frame and create an aperture mask. The method is similar to `lightkurve` but extended to different masks per frame. This is needed for asteroids.

Will need to add before merging:

- [x] Python test
- [ ] Photometry? (EDIT: this will be left for future devs )

Future dev is to use `lkprf` to create a custom aperture that follows the PRF shape