### PR TITLE
Aperture photometry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tess-asteroids"
-version = "0.6.0"
+version = "0.7.0"
 description = "Create TPFs and LCs for solar system asteroids observed by NASA's TESS mission."
 license = "MIT"
 authors = ["Amy Tuson <amy.l.tuson@nasa.gov>",

--- a/src/tess_asteroids/__init__.py
+++ b/src/tess_asteroids/__init__.py
@@ -13,5 +13,5 @@ straps = pd.read_csv(f"{loc}/data/straps.csv", comment="#")
 
 from .movingtpf import MovingTPF  # noqa: E402
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"
 __all__ = ["MovingTPF"]

--- a/src/tess_asteroids/movingtpf.py
+++ b/src/tess_asteroids/movingtpf.py
@@ -959,8 +959,8 @@ class MovingTPF:
                 )
             )
 
-            # Compute flux and bg flux inside aperture - sum of all pixels.
-            # (If mask is all False, these values will be nan.)
+            # Compute flux and bg flux inside aperture (sum of all pixels).
+            # (If no pixels in mask, these values will be nan.)
             ap_flux.append(np.nansum(self.corr_flux[t][mask[-1]]))
             ap_flux_err.append(np.sqrt(np.nansum(self.corr_flux_err[t][mask[-1]] ** 2)))
             ap_bg.append(np.nansum(self.bg[t][mask[-1]]))
@@ -980,6 +980,11 @@ class MovingTPF:
         col_cen, row_cen, col_cen_err, row_cen_err = compute_moments(
             self.corr_flux, np.asarray(mask), second_order=False, return_err=True
         )
+        # Replace zero with nan (i.e. no pixels in mask => no centroid measured)
+        col_cen[col_cen == 0] = np.nan
+        row_cen[row_cen == 0] = np.nan
+        col_cen_err[col_cen_err == 0] = np.nan
+        row_cen_err[row_cen_err == 0] = np.nan
 
         return (
             np.asarray(ap_flux),

--- a/src/tess_asteroids/movingtpf.py
+++ b/src/tess_asteroids/movingtpf.py
@@ -979,9 +979,8 @@ class MovingTPF:
         ap_flux, ap_flux_err, ap_bg, ap_bg_err, col_cen, row_cen, col_cen_err, row_cen_err : ndarrays
             Sum of flux inside aperture and error (ap_flux, ap_flux_err), sum of background flux inside
             aperture and error (ap_bg, ap_bg_err) and flux-weighted centroids inside aperture and errors
-            (col_cen, row_cen, col_cen_err, row_cen_err). The row and column centroids are zero-indexed,
-            where the lower left pixel in the TPF has the value (0,0). To transform this into the pixel
-            position in the full FFI, sum the centroids with `self.corner`.
+            (col_cen, row_cen, col_cen_err, row_cen_err). The row and column centroids are one-indexed and
+            correspond to the position in the full FFI, where the lower left pixel has the value (1,1).
         """
 
         if (
@@ -1034,7 +1033,6 @@ class MovingTPF:
 
         # Compute flux-weighted centroid inside aperture
         # These values are zero-indexed i.e. lower left pixel in TPF is (0,0).
-        # Sum with `self.corner` to get pixel position in full FFI.
         col_cen, row_cen, col_cen_err, row_cen_err = compute_moments(
             self.corr_flux, np.asarray(mask), second_order=False, return_err=True
         )
@@ -1043,6 +1041,10 @@ class MovingTPF:
         row_cen[row_cen == 0] = np.nan
         col_cen_err[col_cen_err == 0] = np.nan
         row_cen_err[row_cen_err == 0] = np.nan
+
+        # Sum centroid with `self.corner` to get pixel position in full FFI.
+        col_cen += self.corner[:, 1]
+        row_cen += self.corner[:, 0]
 
         return (
             np.asarray(ap_flux),

--- a/src/tess_asteroids/movingtpf.py
+++ b/src/tess_asteroids/movingtpf.py
@@ -979,7 +979,9 @@ class MovingTPF:
         ap_flux, ap_flux_err, ap_bg, ap_bg_err, col_cen, row_cen, col_cen_err, row_cen_err : ndarrays
             Sum of flux inside aperture and error (ap_flux, ap_flux_err), sum of background flux inside
             aperture and error (ap_bg, ap_bg_err) and flux-weighted centroids inside aperture and errors
-            (col_cen, row_cen, col_cen_err, row_cen_err).
+            (col_cen, row_cen, col_cen_err, row_cen_err). The row and column centroids are zero-indexed,
+            where the lower left pixel in the TPF has the value (0,0). To transform this into the pixel
+            position in the full FFI, sum the centroids with `self.corner`.
         """
 
         if (
@@ -1031,6 +1033,8 @@ class MovingTPF:
                 ap_bg_err[-1] = np.nan
 
         # Compute flux-weighted centroid inside aperture
+        # These values are zero-indexed i.e. lower left pixel in TPF is (0,0).
+        # Sum with `self.corner` to get pixel position in full FFI.
         col_cen, row_cen, col_cen_err, row_cen_err = compute_moments(
             self.corr_flux, np.asarray(mask), second_order=False, return_err=True
         )

--- a/src/tess_asteroids/movingtpf.py
+++ b/src/tess_asteroids/movingtpf.py
@@ -919,13 +919,13 @@ class MovingTPF:
 
     def to_lightcurve(self, method: str = "aperture", **kwargs):
         """
-        Extract lightcurve from the moving TPF, using either `aperture` or `prf` photometry.
+        Extract lightcurve from the moving TPF, using either `aperture` or `psf` photometry.
         This function creates the `self.lc` attribute, which stores the time series data.
 
         Parameters
         ----------
         method : str
-            Method to extract lightcurve. One of `aperture` or `prf`.
+            Method to extract lightcurve. One of `aperture` or `psf`.
         kwargs : dict
             Keyword arguments, e.g `self._aperture_photometry` takes `bad_bits`.
 
@@ -956,11 +956,11 @@ class MovingTPF:
                 "quality": quality,
             }
 
-        elif method == "prf":
+        elif method == "psf":
             raise NotImplementedError("PSF photometry is not yet implemented.")
         else:
             raise ValueError(
-                f"Method must be one of: ['aperture', 'prf']. Not '{method}'"
+                f"Method must be one of: ['aperture', 'psf']. Not '{method}'"
             )
 
     def _aperture_photometry(self, bad_bits: list = [1, 3]):
@@ -1075,7 +1075,7 @@ class MovingTPF:
         Parameters
         ----------
         method : str
-            Photometric extraction method. One of `aperture` or `prf`.
+            Photometric extraction method. One of `aperture` or `psf`.
 
         Returns
         -------
@@ -1159,12 +1159,12 @@ class MovingTPF:
                 # Add flag for negative pixels in aperture?
             }
 
-        elif method == "prf":
+        elif method == "psf":
             raise NotImplementedError("PSF photometry is not yet implemented.")
 
         else:
             raise ValueError(
-                f"Method must be one of: ['aperture', 'prf']. Not '{method}'"
+                f"Method must be one of: ['aperture', 'psf']. Not '{method}'"
             )
 
         # Compute bit-wise mask

--- a/src/tess_asteroids/utils.py
+++ b/src/tess_asteroids/utils.py
@@ -2,6 +2,8 @@
 Utility functions
 """
 
+from typing import Optional
+
 import numpy as np
 
 
@@ -40,7 +42,12 @@ def inside_ellipse(x, y, cxx, cyy, cxy, x0=0, y0=0, R=1):
     return cxx * (x - x0) ** 2 + cyy * (y - y0) ** 2 + cxy * (x - x0) * (y - y0) <= R**2
 
 
-def compute_moments(flux, mask=None):
+def compute_moments(
+    flux: np.ndarray,
+    mask: Optional[np.ndarray] = None,
+    second_order: bool = True,
+    return_err: bool = False,
+):
     """
     Computes first and second order moments of a 2d distribution over time
     using a coordinate grid with the same shape as `flux` (nt, nrows, ncols).
@@ -52,16 +59,22 @@ def compute_moments(flux, mask=None):
     ----------
     flux: ndarray
         3D array with flux values as (nt, nrows, ncols).
-    mask: ndarray, boolean
+    mask: ndarray
         Mask to select pixels used for computing moments. Shape could
         be 3D (nt, nrows, ncols) or 2D (nrows, ncols). If a 2D mask is given,
         it is used for all frames `nt`.
+    second_order: bool
+        If True, returns first and second order moments, else returns only first
+        order moments.
+    return_err: bool
+        If True, returns error on first order moments.
 
     Returns
     -------
-    X, Y, X2, Y2, XY: ndarrays
-        First (X, Y) and second (X2, Y2, XY) order moments. Each array has
-        shape (nt).
+    X, Y, XERR, YERR, X2, Y2, XY: ndarrays
+        First (X, Y) and second (X2, Y2, XY) order moments, plus error on first order moments (XERR, YERR).
+        If `second_order` is False, X2,Y2,XY are not returned. If `return_err` is False, XERR,YERR are
+        not returned. Each array has shape (nt).
     """
     # check if mask is None
     if mask is None:
@@ -70,11 +83,18 @@ def compute_moments(flux, mask=None):
     if len(mask.shape) == 2:
         mask = np.repeat([mask], flux.shape[0], axis=0)
 
+    # remove negative values in flux (possible artefact of bg subtraction)
+    mask = np.logical_and(mask, flux >= 0)
+
     X = np.zeros(flux.shape[0], dtype=float)
     Y = np.zeros(flux.shape[0], dtype=float)
-    X2 = np.zeros(flux.shape[0], dtype=float)
-    Y2 = np.zeros(flux.shape[0], dtype=float)
-    XY = np.zeros(flux.shape[0], dtype=float)
+    if second_order:
+        X2 = np.zeros(flux.shape[0], dtype=float)
+        Y2 = np.zeros(flux.shape[0], dtype=float)
+        XY = np.zeros(flux.shape[0], dtype=float)
+    if return_err:
+        XERR = np.zeros(flux.shape[0], dtype=float)
+        YERR = np.zeros(flux.shape[0], dtype=float)
 
     # compute moments for each frame
     for nt in range(flux.shape[0]):
@@ -87,11 +107,43 @@ def compute_moments(flux, mask=None):
         # first order moments
         Y[nt] = np.average(row[mask[nt]], weights=flux[nt, mask[nt]])
         X[nt] = np.average(col[mask[nt]], weights=flux[nt, mask[nt]])
-        # second order moments
-        Y2[nt] = np.average(row[mask[nt]] ** 2, weights=flux[nt, mask[nt]]) - Y[nt] ** 2
-        X2[nt] = np.average(col[mask[nt]] ** 2, weights=flux[nt, mask[nt]]) - X[nt] ** 2
-        XY[nt] = (
-            np.average(row[mask[nt]] * col[mask[nt]], weights=flux[nt, mask[nt]])
-            - X[nt] * Y[nt]
-        )
-    return X, Y, X2, Y2, XY
+        if second_order or return_err:
+            # second order moments
+            Y2[nt] = (
+                np.average(row[mask[nt]] ** 2, weights=flux[nt, mask[nt]]) - Y[nt] ** 2
+            )
+            X2[nt] = (
+                np.average(col[mask[nt]] ** 2, weights=flux[nt, mask[nt]]) - X[nt] ** 2
+            )
+            XY[nt] = (
+                np.average(row[mask[nt]] * col[mask[nt]], weights=flux[nt, mask[nt]])
+                - X[nt] * Y[nt]
+            )
+        if return_err:
+            # error on first-order moments (assumes uncertainties on weights are similar)
+            # see eqn. 6 in https://seismo.berkeley.edu/~kirchner/Toolkits/Toolkit_12.pdf
+            XERR[nt] = np.sqrt(
+                X2[nt]
+                * (np.nansum(flux[nt, mask[nt]] ** 2))
+                / (
+                    np.nansum(flux[nt, mask[nt]]) ** 2
+                    - np.nansum(flux[nt, mask[nt]] ** 2)
+                )
+            )
+            YERR[nt] = np.sqrt(
+                Y2[nt]
+                * (np.nansum(flux[nt, mask[nt]] ** 2))
+                / (
+                    np.nansum(flux[nt, mask[nt]]) ** 2
+                    - np.nansum(flux[nt, mask[nt]] ** 2)
+                )
+            )
+
+    if second_order and return_err:
+        return X, Y, XERR, YERR, X2, Y2, XY
+    elif second_order and not return_err:
+        return X, Y, X2, Y2, XY
+    elif return_err and not second_order:
+        X, Y, XERR, YERR
+    else:
+        X, Y

--- a/src/tess_asteroids/utils.py
+++ b/src/tess_asteroids/utils.py
@@ -83,12 +83,14 @@ def compute_moments(
     if len(mask.shape) == 2:
         mask = np.repeat([mask], flux.shape[0], axis=0)
 
-    # remove negative values in flux (possible artefact of bg subtraction)
+    # mask negative values in flux (possible artefact of bg subtraction)
     mask = np.logical_and(mask, flux >= 0)
+    # mask nans in flux
+    mask = np.logical_and(mask, np.isfinite(flux))
 
     X = np.zeros(flux.shape[0], dtype=float)
     Y = np.zeros(flux.shape[0], dtype=float)
-    if second_order:
+    if second_order or return_err:
         X2 = np.zeros(flux.shape[0], dtype=float)
         Y2 = np.zeros(flux.shape[0], dtype=float)
         XY = np.zeros(flux.shape[0], dtype=float)
@@ -144,6 +146,6 @@ def compute_moments(
     elif second_order and not return_err:
         return X, Y, X2, Y2, XY
     elif return_err and not second_order:
-        X, Y, XERR, YERR
+        return X, Y, XERR, YERR
     else:
-        X, Y
+        return X, Y

--- a/src/tess_asteroids/utils.py
+++ b/src/tess_asteroids/utils.py
@@ -101,8 +101,8 @@ def compute_moments(
 
     # compute moments for each frame
     for nt in range(flux.shape[0]):
-        # skip frame if no pixels are used
-        if mask[nt].sum() == 0:
+        # skip frame if no pixels are used or fluxes sum to zero
+        if mask[nt].sum() == 0 or flux[nt, mask[nt]].sum() == 0:
             continue
         # dummy pixel grid
         row, col = np.mgrid[0 : flux.shape[1], 0 : flux.shape[2]]

--- a/tests/test_movingtpf.py
+++ b/tests/test_movingtpf.py
@@ -306,14 +306,13 @@ def test_to_lightcurve():
     assert len(target.lc["aperture"]["quality"]) == len(target.time)
 
     # Check the average centroid is within 1/2 a pixel of the center of the TPF.
-    # Remember: centroids are zero-indexed!
     assert (
-        (np.nanmean(target.lc["aperture"]["row_cen"]) > 4.5)
-        & (np.nanmean(target.lc["aperture"]["row_cen"]) < 5.5)
+        (np.nanmean(target.lc["aperture"]["row_cen"] - target.corner[:, 0]) > 4.5)
+        & (np.nanmean(target.lc["aperture"]["row_cen"] - target.corner[:, 0]) < 5.5)
     ).all()
     assert (
-        (np.nanmean(target.lc["aperture"]["col_cen"]) > 4.5)
-        & (np.nanmean(target.lc["aperture"]["col_cen"]) < 5.5)
+        (np.nanmean(target.lc["aperture"]["col_cen"] - target.corner[:, 1]) > 4.5)
+        & (np.nanmean(target.lc["aperture"]["col_cen"] - target.corner[:, 1]) < 5.5)
     ).all()
 
     # Check the pixel quality has been correctly accounted for in quality mask.

--- a/tests/test_movingtpf.py
+++ b/tests/test_movingtpf.py
@@ -283,7 +283,7 @@ def test_make_tpf():
 
 def test_to_lightcurve():
     """
-    Test the to_lightcurve() function, with the method `aperture`.  This internally calls
+    Test the to_lightcurve() function with the method `aperture`.  This internally calls
     _aperture_photometry() and _create_lc_quality(). The tests check the expected length
     of the lightcurve, the expected value of the centroid and the expected values of the
     quality mask.
@@ -306,6 +306,7 @@ def test_to_lightcurve():
     assert len(target.lc["aperture"]["quality"]) == len(target.time)
 
     # Check the average centroid is within 1/2 a pixel of the center of the TPF.
+    # Remember: centroids are zero-indexed!
     assert (
         (np.nanmean(target.lc["aperture"]["row_cen"]) > 4.5)
         & (np.nanmean(target.lc["aperture"]["row_cen"]) < 5.5)

--- a/tests/test_movingtpf.py
+++ b/tests/test_movingtpf.py
@@ -279,3 +279,43 @@ def test_make_tpf():
 
     # Delete the file
     os.remove("tests/tess-1998YT6-s0006-1-1-shape11x11-moving_tp.fits")
+
+
+def test_to_lightcurve():
+    """
+    Test the to_lightcurve() function, with the method `aperture`.  This internally calls
+    _aperture_photometry() and _create_lc_quality(). The tests check the expected length
+    of the lightcurve, the expected value of the centroid and the expected values of the
+    quality mask.
+    """
+
+    # Make TPF for asteroid 1998 YT6.
+    target, _ = MovingTPF.from_name("1998 YT6", sector=6)
+    target.get_data()
+    target.reshape_data()
+    target.create_pixel_quality()
+    target.background_correction()
+
+    # Use aperture photometry to extract lightcurve from TPF.
+    target.create_aperture()
+    target.to_lightcurve(method="aperture")
+
+    # Check the lightcurve has the same length as target.time
+    assert len(target.lc["aperture"]["time"]) == len(target.time)
+    assert len(target.lc["aperture"]["flux"]) == len(target.time)
+    assert len(target.lc["aperture"]["quality"]) == len(target.time)
+
+    # Check the average centroid is within 1/2 a pixel of the center of the TPF.
+    assert (
+        (np.nanmean(target.lc["aperture"]["row_cen"]) > 4.5)
+        & (np.nanmean(target.lc["aperture"]["row_cen"]) < 5.5)
+    ).all()
+    assert (
+        (np.nanmean(target.lc["aperture"]["col_cen"]) > 4.5)
+        & (np.nanmean(target.lc["aperture"]["col_cen"]) < 5.5)
+    ).all()
+
+    # Check the pixel quality has been correctly accounted for in quality mask.
+    for t in range(len(target.time)):
+        if target.pixel_quality[t][target.aperture_mask[t]].any() != 0:
+            assert target.lc["aperture"]["quality"][t] > 0


### PR DESCRIPTION
This PR introduces aperture photometry. It computes the target flux, BG flux and flux-weighted centroid inside an aperture and creates a quality flag for each cadence.

- Created functions `_aperture_photometry()` and `_create_lc_quality()`.
- Created the wrapper function `to_lightcurve()`. This creates the `self.lc` attribute.
- Updated the `compute_moments()` function: removes negative and nan values before computing moments, adds computation of errors for first-order moments, makes computation of second-order moments optional.
- Added test for new functions.
- Bumped version number to 0.7.0.
