### PR TITLE
Update availability of SPICE kernels

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ pip install tess-asteroids
 
 `tess-asteroids` uses `lkspacecraft` to derive barycentric time corrections (see [below](https://github.com/altuson/tess-asteroids?tab=readme-ov-file#barycentric-time-correction)). **The first time you run `lkspacecraft` it will download a set of files (the SPICE kernels for TESS). This will take approximately 5 minutes, depending on your internet connection, and the total file volume will be about 1GB.** The files will be cached once they are downloaded and if a new version of any file becomes available they will be automatically retrieved.
 
-Note: some of the files for early TESS sectors are currently missing from the archive. This is a known [issue](https://github.com/lightkurve/lkspacecraft/issues/4) and the files will be made available in the future.
-
 ## Quickstart
 
 You can easily make and save a TPF and LCF for any object in the JPL Small-Body Database that has been observed by TESS. For example,
@@ -189,9 +187,7 @@ For more information about time scales, see the `astropy` [documentation](https:
 
 ### Barycentric time correction
 
-The barycentric time correction derived by SPOC (BARYCORR) is used to transform the time in UTC at the spacecraft into the time in TDB at the solar system barycenter. This correction is calculated at the center of each FFI (i.e. one correction for each CCD) but, in reality, the correction depends upon RA and Dec. Therefore, within `tess-asteroids` we re-derive the barycentric time correction based upon the position of the moving target. In the output TPFs and LCFs, you will see columns called ORIGINAL_TIME (FFI timestamp in TDB at barycenter, as derived by SPOC), ORIGINAL_TIMECORR (correction to transform UTC at spacecraft into TDB at barycenter, as derived by SPOC), TIME (re-derived time in TDB at barycenter) and TIMECORR (re-derived time correction).
-
-The barycentric time correction is derived using `lkspacecraft`, but some of the files needed to compute the correction are missing for early TESS sectors. This is a known [issue](https://github.com/lightkurve/lkspacecraft/issues/4) and the files will be made available in the future. In the meantime, you might notice that the TIME and ORIGINAL_TIME columns are the same for some of your targets. This means the barycentric time correction was not re-derived and the timestamps in those files will be less accurate. 
+The barycentric time correction derived by SPOC (BARYCORR) is used to transform the time in UTC at the spacecraft into the time in TDB at the solar system barycenter. This correction is calculated at the center of each FFI (i.e. one correction for each CCD) but, in reality, the correction depends upon RA and Dec. Therefore, within `tess-asteroids` we use `lkspacecraft` to re-derive the barycentric time correction based upon the position of the moving target. In the output TPFs and LCFs, you will see columns called ORIGINAL_TIME (FFI timestamp in TDB at barycenter, as derived by SPOC), ORIGINAL_TIMECORR (correction to transform UTC at spacecraft into TDB at barycenter, as derived by SPOC), TIME (re-derived time in TDB at barycenter) and TIMECORR (re-derived time correction).
 
 ## Understanding the TPF and LCF
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tess-asteroids"
-version = "1.1.0"
+version = "1.1.1"
 description = "Create TPFs and LCs for solar system asteroids observed by NASA's TESS mission."
 license = "MIT"
 authors = ["Amy Tuson <amy.l.tuson@nasa.gov>",

--- a/src/tess_asteroids/__init__.py
+++ b/src/tess_asteroids/__init__.py
@@ -11,7 +11,7 @@ logger.addHandler(logging.StreamHandler())
 loc = path.abspath(path.dirname(__file__))
 straps = pd.read_csv(f"{loc}/data/straps.csv", comment="#")
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 __all__ = ["MovingTPF"]
 
 from .movingtpf import MovingTPF  # noqa: E402

--- a/src/tess_asteroids/movingtpf.py
+++ b/src/tess_asteroids/movingtpf.py
@@ -375,8 +375,7 @@ class MovingTPF:
         )
 
         # Calculate UTC to TDB correction using position of object.
-        # This will not work for some early sectors due to missing SPICE kernels. This is a
-        # known issue and, once it is fixed, the try/except can be removed.
+        # If SPICE kernels are missing, no correction will be computed.
         try:
             time_utc = self.time_original - self.timecorr_original
             # Catch warnings.

--- a/tests/test_movingtpf.py
+++ b/tests/test_movingtpf.py
@@ -298,9 +298,8 @@ def test_make_tpf():
         assert len(hdul[3].data["APERTURE"]) == len(target.time)
         assert np.array_equal(target.corr_flux, hdul[1].data["FLUX"])
 
-        # As long as SPICE kernels are still missing, TIME and TIME_ORIGINAL should be
-        # identical. When this test fails, we know the kernels have been updated.
-        assert (hdul[1].data["TIME"] == hdul[3].data["ORIGINAL_TIME"]).all()
+        # Check the UTC to TDB conversion has been applied.
+        assert (hdul[1].data["TIME"] != hdul[3].data["ORIGINAL_TIME"]).all()
 
     # Check the file can be opened with lightkurve
     tpf = lk.read(
@@ -392,9 +391,8 @@ def test_make_lc():
         assert "RA" in hdul[1].columns.names
         assert "EPHEM1" in hdul[1].columns.names
 
-        # As long as SPICE kernels are still missing, TIME and TIME_ORIGINAL should be
-        # identical. When this test fails, we know the kernels have been updated.
-        assert (hdul[1].data["TIME"] == hdul[1].data["ORIGINAL_TIME"]).all()
+        # Check the UTC to TDB conversion has been applied.
+        assert (hdul[1].data["TIME"] != hdul[1].data["ORIGINAL_TIME"]).all()
 
     # Check the file can be opened with lightkurve
     lc = lk.io.tess.read_tess_lightcurve(


### PR DESCRIPTION
In PR https://github.com/altuson/tess-asteroids/pull/21, we introduced a barycentric time calculation to `tess-asteroids`. At that time, some of the SPICE kernels were missing for early TESS sectors (see this [issue](https://github.com/lightkurve/lkspacecraft/issues/4)) and we had to account for that. These files are now available so this PR makes minor updates to reflect this:
- Update test to check time correction has been applied for asteroid 1998 YT6 in sector 6. 
- Update README documentation.
- Bump patch version number.

