### PR TITLE
Update required version of tess-ephem

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3886,13 +3886,13 @@ tests = ["cython", "littleutils", "pygments", "pytest", "typeguard"]
 
 [[package]]
 name = "tess-ephem"
-version = "0.6.0"
+version = "0.6.1"
 description = "Where are Solar System objects located in TESS FFI data?"
 optional = false
 python-versions = "<4.0,>=3.9"
 files = [
-    {file = "tess_ephem-0.6.0-py3-none-any.whl", hash = "sha256:48a120037dca351ed29396c1f0fb2a9c3c0289de3ecdb224e0e014e7617ef82a"},
-    {file = "tess_ephem-0.6.0.tar.gz", hash = "sha256:e79076219b6b711e74a7e923cba99c8cc3aa02a7ec7ff39dd126d60655d1b789"},
+    {file = "tess_ephem-0.6.1-py3-none-any.whl", hash = "sha256:d1751427167a13157f92834bade04b8eb92b29ad80f068e1866b1a20a93e5a30"},
+    {file = "tess_ephem-0.6.1.tar.gz", hash = "sha256:a6e51fbd9e4d6fa9514c29784870339e1f182bb87ceac0353d918a2a99b10ae9"},
 ]
 
 [package.dependencies]
@@ -4425,4 +4425,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9, <3.13"
-content-hash = "0c5b2f5cdf92f21cf57b26876287a5eaadff9a003ea65be07da8c4fe0396ee1c"
+content-hash = "a54f26652498844903c1f11f17fa877e38f5cb104c0e08d7bfa704c8ec564fb9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ packages = [{include = "tess_asteroids", from = "src"}]
 
 [tool.poetry.dependencies]
 python = ">=3.9, <3.13"
-tess-ephem = "^0.6.0"
+tess-ephem = "^0.6.1"
 tesscube = "^1.2"
 numpy = "^1.26.4"
 pandas = "^2.0"

--- a/src/tess_asteroids/movingtpf.py
+++ b/src/tess_asteroids/movingtpf.py
@@ -1508,9 +1508,13 @@ class MovingTPF:
                 np.sqrt(np.sum(np.diff(self.ephemeris, axis=0) ** 2, axis=1))
             )
             # Pixel resolution at which to evaluate PRF model
-            resolution = 0.1 if track_length > 0.1 else track_length
+            resolution = 0.1
             # Time resolution at which to evaluate PRF model
             time_step = (cadence / track_length) * resolution
+            # If time_step is greater than observing cadence, set time_step a small fraction less
+            # than observing cadence. time_step must be less than cadence for inteprolation.
+            if time_step >= cadence:
+                time_step = 0.99 * cadence
             logger.info(
                 "_create_target_prf_model() calculated a time_step of {0} minutes.".format(
                     time_step
@@ -2519,7 +2523,7 @@ class MovingTPF:
                 ),
                 3,
             ),
-            comment='[arcsec/h] average RA rate',
+            comment="[arcsec/h] average RA rate",
             after="ORBINC",
         )
         hdu.header.set(
@@ -2532,7 +2536,7 @@ class MovingTPF:
                 ),
                 3,
             ),
-            comment='[arcsec/h] average Dec rate',
+            comment="[arcsec/h] average Dec rate",
             after="RARATE",
         )
         # Pixel speed is computed from input ephemeris so TPF and LCF can use consistent values.

--- a/src/tess_asteroids/movingtpf.py
+++ b/src/tess_asteroids/movingtpf.py
@@ -2519,7 +2519,7 @@ class MovingTPF:
                 ),
                 3,
             ),
-            comment='["/h] average RA rate',
+            comment='[arcsec/h] average RA rate',
             after="ORBINC",
         )
         hdu.header.set(
@@ -2532,7 +2532,7 @@ class MovingTPF:
                 ),
                 3,
             ),
-            comment='["/h] average Dec rate',
+            comment='[arcsec/h] average Dec rate',
             after="RARATE",
         )
         # Pixel speed is computed from input ephemeris so TPF and LCF can use consistent values.
@@ -2611,7 +2611,7 @@ class MovingTPF:
                 name="RAW_CNTS",
                 format=tform.replace("E", "I"),
                 dim=dims,
-                unit="e-/s",
+                unit="ADU",
                 disp="I8",
                 array=np.zeros_like(self.corr_flux),
             ),

--- a/src/tess_asteroids/movingtpf.py
+++ b/src/tess_asteroids/movingtpf.py
@@ -423,7 +423,7 @@ class MovingTPF:
         # `self.coords` does not recover these original values because the
         # ephemeris has since been interpolated.
         # Note: pixel_to_world() assumes zero-indexing so subtract one from (row,col).
-        self.wcs = tesswcs.WCS.from_archive(
+        self.wcs = tesswcs.WCS.from_sector(
             sector=self.sector, camera=self.camera, ccd=self.ccd
         )
         self.coords = np.asarray(


### PR DESCRIPTION
This PR updates minimum required version of `tess-ephem` to 0.6.1. This resolves an issue that was causing slow down in runtime (see https://github.com/SSDataLab/tess-ephem/pull/16).

This PR also makes some housekeeping updates:

- Updates units of RAW_CNTS in TPF to ADU. 
- Updates units of RARATE and DECRATE in headers to arcsec/h. 
- Replaces deprecated `tesswcs` `from_archive()` function with `from_sector()`. 
- Fixes PRF model `time_step` bug. If `time_step` was equal to observing cadence, then the PRF model was breaking. This has been fixed by requiring `time_step` to be a small fraction less than observing cadence.