### PR TITLE
Implementing PSF photometry

### DIFF
--- a/tests/test_movingtpf.py
+++ b/tests/test_movingtpf.py
@@ -422,6 +422,26 @@ def test_to_lightcurve():
         < 1
     ).all()
 
+    # Test PSF photometry to extract lightcurve from TPF.
+    target.to_lightcurve(method="psf", time_binning=1, cadence_quality=False)
+
+    # Check the lightcurve has the same length as target.time
+    assert len(target.lc["psf"]["time"]) == len(target.time)
+    assert len(target.lc["psf"]["flux"]) == len(target.time)
+    assert len(target.lc["psf"]["flux_err"]) == len(target.time)
+    assert len(target.lc["psf"]["TESSmag"]) == len(target.time)
+    assert len(target.lc["psf"]["TESSmag_err"]) == len(target.time)
+    assert len(target.lc["psf"]["fit_quality"]) == len(target.time)
+    assert len(target.lc["psf"]["flux_fraction"]) == len(target.time)
+
+    # check the total number of failed cadences is equal or greater than the number of
+    # bad cadences
+    assert np.sum(target.lc["psf"]["fit_quality"] == 0) >= np.sum(target.quality == 0)
+    # check flux fraction is 1
+    assert np.all(target.lc["psf"]["flux_fraction"] == 1)
+    # check chi2 values are positives
+    assert np.all(target.lc["psf"]["chi2"][target.lc["psf"]["fit_quality"] == 0] >= 0)
+
 
 def test_calculate_TESSmag():
     """


### PR DESCRIPTION
This PR adds PSF photometry. This is done in the new `_psf_photometry()` method which does PRF fitting with a linear model to the flux data to compute the photometry. The method also allows for cadence binning which helps to improve SNR. 

List of ToDo
- [ ] Implement `_psf_photometry()` with time binning
- [ ] Implement `fit_quality` from linear model solving
- [ ] Add "psf" method to `to_lightcurve()`
- [ ] Add test for psf photometry to `test_movingtpf.py`
- [ ] Merge pixel quality mask into PSF light curve quality
- [ ] Add PSF light curve into FITS file